### PR TITLE
Added a missing dot

### DIFF
--- a/Model/Behavior/PermitBehavior.php
+++ b/Model/Behavior/PermitBehavior.php
@@ -43,7 +43,7 @@
 					),
 					'check' => false,
 					'value' => true,
-					'field' => $Model->alias . 'user_id',
+					'field' => $Model->alias . '.user_id',
 					'skip'  => true,
 					'rules' => array(),
 				);


### PR DESCRIPTION
I could be misunderstanding how this is meant to work, but if the 'field' value is meant to use the `Model.field` syntax, then you're missing a dot.
