### PR TITLE
Minor update to user() method

### DIFF
--- a/Model/Behavior/PermitBehavior.php
+++ b/Model/Behavior/PermitBehavior.php
@@ -113,7 +113,7 @@
 
 			$adminCheck = $settings['check'];
 			$adminValue = $settings['value'];
-			if ($adminCheck && $this->user($Model, $adminCheck, $results) == $adminValue) {
+			if ($adminCheck && $this->user($Model, $results, $adminCheck) == $adminValue) {
 				return $results;
 			}
 
@@ -125,11 +125,11 @@
 	 *
 	 * Can be overriden in the Model to provide advanced control
 	 *
-	 * @param string $key field to retrieve.  Leave null to get entire User record
 	 * @param array $result single Model record being authenticated against
+	 * @param string $key field to retrieve.  Leave null to get entire User record
 	 * @return mixed User record. or null if no user is logged in.
 	 */
-		public function user(Model $Model, $key = null, $result = array()) {
+		public function user(Model $Model, $result, $key = null) {
 			if (method_exists($Model, 'user')) {
 				return $Model->user($key, $result);
 			}
@@ -145,7 +145,7 @@
 			if (method_exists($Model, 'get')) {
 				$className = get_class($Model);
 				$ref = new ReflectionMethod($className, 'get');
-				if ($refl->isStatic()) {
+				if ($ref->isStatic()) {
 					return $className::get($key);
 				}
 			}


### PR DESCRIPTION
The values passed into the user() method were in the wrong order, which was causing issues with the operations within it.

I've taken some artistic licence and forced result to be a required field (by removing the `= array()`) as I figure this is more likely to be needed.

I've also fixed what I think was a typo on line 148 - although I've not tested it.

Please note, however, that lines 114-118 don't make any sense to me, I'm not too sure exactly what they're meant to be doing, so I'm not sure how they're meant to relate to the user() method.
