### PR TITLE
Added permit() method

### DIFF
--- a/Model/Behavior/PermitBehavior.php
+++ b/Model/Behavior/PermitBehavior.php
@@ -49,7 +49,6 @@
 				);
 			}
 			$this->settings[$Model->alias] = array_merge($this->settings[$Model->alias], $settings);
-			$this->modelDefaults[$Model->alias] = $this->settings[$Model->alias];
 		}
 
 
@@ -61,8 +60,6 @@
 	 * @return array Modified query
 	 */
 		public function beforeFind(Model $Model, $query) {
-			$this->settings[$Model->alias] = $this->modelDefaults[$Model->alias];
-
 			if (isset($query['permit']) && isset($this->settings[$Model->alias]['rules'][$query['permit']])) {
 				$rules = $this->settings[$Model->alias]['rules'][$query['permit']];
 				if (isset($rules['rules'])) {
@@ -151,6 +148,16 @@
 			}
 
 			return false;
+		}
+
+	/**
+	 * Used to dynamically assign permit settings
+	 *
+	 * @param array $settings same as the settings used to set-up the model
+	 * @return void
+	 */
+		public function permit(Model $Model, $settings = array()) {
+			$this->settings[$Model->alias] = array_merge($this->settings[$Model->alias], $settings);
 		}
 
 	}


### PR DESCRIPTION
Because I prefer using `read()` (rather than `find('first')`) to get records from the database for editing purposes, and because you're unable to pass any extra parameters to the `read()` method, I've created a simple `permit()` method to let you activate the permit behaviour dynamically.

Where as before, I would have to use the following find code to pull the data ready for editing (which, while simple enough, is a little messy):

```
$params = array(
    'conditions' => array('id' => $id),
    'permit_skip' => false,
);
$this->request->data = $this->Story->find('first', $params);
```

I'm now able to do this instead:

```
$this->Story->permit(array('skip' => false));
$this->request->data = $this->Story->read(null, $id);
```

For this to work, however, I've had to remove all references to `$this->modelDefaults` as this was overwriting the settings I passed in via `permit()`. There may be some higher purpose to `$this->modelDefaults` that I don't understand, in which case I'll have to figure out another way of doing this.

But if not, I hope this will make a good addition to the plugin.

:{) <--- movember
